### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Reference the base in your `kustomization.yaml`:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - github.com/utilitywarehouse/docker-registry-manifests//base?ref=v1.1.2
+  - github.com/utilitywarehouse/docker-registry-manifests//base?ref=1.1.0
 ```
 
 ## Example

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../base
-#- github.com/utilitywarehouse/docker-registry-manifests//base?ref=v1.1.2
+#- github.com/utilitywarehouse/docker-registry-manifests//base?ref=1.1.0
 resources:
   - registry-ingress.yaml
 patchesStrategicMerge:


### PR DESCRIPTION
Bump up to `1.1.0` on account of breaking change in base path and patch requirements. Remove the `v` from the version string.

I accidentally committed the bogus version `v1.1.2` to the `README.md` and `kustomization.yaml` in my previous commit, the actual previous version is `v1.0.2`. I just forgot how versioning worked for two seconds 🤦‍♂ .