### PR TITLE
Replace the frontend

### DIFF
--- a/base/registry-frontend.yaml
+++ b/base/registry-frontend.yaml
@@ -14,12 +14,14 @@ spec:
     - name: frontend
       protocol: TCP
       port: 80
+      targetPort: 8000
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: docker-registry-frontend
 spec:
+  serviceName: docker-registry-frontend
   replicas: 1
   selector:
     matchLabels:
@@ -30,6 +32,84 @@ spec:
       labels:
         app: docker-registry-frontend
     spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      initContainers:
+        # overwrite values in the config file in the overlay
+        - name: frontend-config
+          image: alpine
+          command:
+            - sh
+            - -c
+            - |
+              cat <<"EOF" > /var/docker-registry-ui/config.yml
+              # Adapted from: https://github.com/Quiq/docker-registry-ui/blob/0.9.3/config.yml
+
+              # Listen interface.
+              listen_addr: 0.0.0.0:8000
+              # Base path of Docker Registry UI.
+              base_path: /
+
+              # Registry URL with schema and port.
+              registry_url: http://localhost:5000
+
+              # Verify TLS certificate when using https.
+              verify_tls: true
+
+              # UW: the registry runs on localhost without any authentication
+              # Docker registry credentials.
+              # They need to have a full access to the registry.
+              # If token authentication service is enabled, it will be auto-discovered and those credentials
+              # will be used to obtain access tokens.
+              # When the registry_password_file entry is used, the password can be passed as a docker secret
+              # and read from file. This overides the registry_password entry.
+              # registry_username: user
+              # registry_password: pass
+              # registry_password_file: /run/secrets/registry_password_file
+
+              # Event listener token.
+              # The same one should be configured on Docker registry as Authorization Bearer token.
+              event_listener_token: $(EVENT_LISTENER_TOKEN)
+              # Retention of records to keep.
+              event_retention_days: 7
+
+              # Event listener storage.
+              event_database_driver: sqlite3
+              event_database_location: data/registry_events.db
+              # event_database_driver: mysql
+              # event_database_location: user:password@tcp(localhost:3306)/docker_events
+
+              # You can disable event deletion on some hosts when you are running docker-registry on master-master or
+              # cluster setup to avoid deadlocks or replication break.
+              event_deletion_enabled: true
+
+              # Cache refresh interval in minutes.
+              # How long to cache repository list and tag counts.
+              cache_refresh_interval: 10
+
+              # If users can delete tags. If set to False, then only admins listed below.
+              anyone_can_delete: false
+              # Users allowed to delete tags.
+              # This should be sent via X-WEBAUTH-USER header from your proxy.
+              admins: []
+
+              # Debug mode. Affects only templates.
+              debug: true
+
+              # How many days to keep tags but also keep the minimal count provided no matter how old.
+              purge_tags_keep_days: 90
+              purge_tags_keep_count: 2
+              # Enable built-in cron to schedule purging tags in server mode.
+              # Empty string disables this feature.
+              # Example: '25 54 17 * * *' will run it at 17:54:25 daily.
+              # Note, the cron schedule format includes seconds! See https://godoc.org/github.com/robfig/cron
+              purge_tags_schedule: ''
+              EOF
+          volumeMounts:
+            - mountPath: /var/docker-registry-ui
+              name: frontend-config
       containers:
         - name: docker-registry
           image: registry:2.7.1
@@ -45,7 +125,9 @@ spec:
               mountPath: /etc/docker/registry/
               readOnly: true
         - name: docker-registry-frontend
-          image: konradkleine/docker-registry-frontend:v2
+          image: quiq/docker-registry-ui:0.9.3
+          args:
+            - -config-file=/var/docker-registry-ui/config.yml
           resources:
             requests:
               cpu: 0m
@@ -53,16 +135,14 @@ spec:
             limits:
               cpu: 100m
               memory: 128Mi
-          env:
-            - name: ENV_DOCKER_REGISTRY_HOST
-              value: "localhost"
-            - name: ENV_DOCKER_REGISTRY_PORT
-              value: "5000"
-            - name: ENV_REGISTRY_PROXY_PORT
-              value: "443"
           ports:
             - name: frontend
-              containerPort: 80
+              containerPort: 8000
+          volumeMounts:
+            - mountPath: /opt/data
+              name: frontend-data
+            - mountPath: /var/docker-registry-ui
+              name: frontend-config
       volumes:
         - name: registry-config
           configMap:
@@ -70,3 +150,14 @@ spec:
             items:
               - key: config.yml
                 path: config.yml
+        - name: frontend-config
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: frontend-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -11,8 +11,14 @@ secretGenerator:
   - name: registry
     envs:
       - secrets/credentials
+    files:
+      - registry_notifications_endpoints=secrets/notifications.yaml
     type: Opaque
   - name: registry-auth
     files:
       - secrets/auth_config.yml
+    type: Opaque
+  - name: registry-frontend
+    envs:
+      - secrets/registry-frontend
     type: Opaque

--- a/example/registry-patch.yaml
+++ b/example/registry-patch.yaml
@@ -31,14 +31,27 @@ spec:
                 secretKeyRef:
                   name: registry
                   key: registry_http_secret
+            - name: REGISTRY_NOTIFICATIONS_ENDPOINTS
+              valueFrom:
+                secretKeyRef:
+                  name: registry
+                  key: registry_notifications_endpoints
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: docker-registry-frontend
 spec:
   template:
     spec:
+      initContainers:
+        - name: frontend-config
+          env:
+            - name: EVENT_LISTENER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: registry-frontend
+                  key: event_listener_token
       containers:
         - name: docker-registry
           env:
@@ -56,7 +69,3 @@ spec:
                 secretKeyRef:
                   name: registry
                   key: registry_storage_s3_secretkey
-        - name: docker-registry-frontend
-          env:
-            - name: ENV_REGISTRY_PROXY_FQDN
-              value: "registry.example.com"

--- a/example/secrets/notifications.yaml
+++ b/example/secrets/notifications.yaml
@@ -1,0 +1,9 @@
+- name: docker-registry-ui
+  url: http://docker-registry-frontend/api/events
+  headers:
+    Authorization: [Bearer TOKENGOESHERE]
+  timeout: 1s
+  threshold: 5
+  backoff: 10s
+  ignoredmediatypes:
+    - application/octet-stream

--- a/example/secrets/registry-frontend
+++ b/example/secrets/registry-frontend
@@ -1,0 +1,1 @@
+event_listener_token=TOKENGOESHERE


### PR DESCRIPTION
The existing frontend fetches the list of repos/tags using the pagination options available in the registry API. This is essentially unusable when you have as many repos as us, because navigating to a specific repo is either:
1. Incredibly cumbersome when you have to click through all the pages
2. Incredibly slow if you fetch a large set of repos

This new frontend fetches the list of repos/tags asynchronously and caches them, meaning that the information is readily available and quick to navigate once it's cached.

It also gives you more information about the manifests AND captures events from the registry (i.e who pushed what image when).